### PR TITLE
Adapt test to demonstrate broken relative imports

### DIFF
--- a/tests/step_definition_app/features/steps/two.py
+++ b/tests/step_definition_app/features/steps/two.py
@@ -20,7 +20,9 @@ Part of steps for the tested application.
 
 from aloe import step
 
+from .one import *
 
-@step(r'I use step one')
-def step_one(self):
+
+@step(r'I use step two')
+def step_two(self):
     pass


### PR DESCRIPTION
From https://github.com/gabrielfalcao/lettuce/issues/431 -- Lettuce's
step loader, on which Aloe is based, cannot handle relative imports.

The problem appears to be caused by adding the directory itself to the
package import root (this would make it an absolute import). It would be
better not to manipulate the import path and instead determine the
Python package path for the file we wish to import from a path we
already have.
