### PR TITLE
Cucumber outputter

### DIFF
--- a/aloe/parser.py
+++ b/aloe/parser.py
@@ -279,7 +279,7 @@ class Step(Node):
                                                         table=False,
                                                         multiline=False)),
             *[strings.get_terminal_width(line)
-              for line in self.represent_hashes().splitlines()]
+              for line in self.represent_table().splitlines()]
         )
 
     # pylint:disable=too-many-arguments,arguments-differ
@@ -293,8 +293,8 @@ class Step(Node):
         lines = [color(super().represented(indent=indent, annotate=annotate))]
 
         if table and self.table:
-            lines.append(self.represent_hashes(indent=indent + 2,
-                                               cell_wrap=color))
+            lines.append(self.represent_table(indent=indent + 2,
+                                              cell_wrap=color))
 
         if multiline and self.multiline:
             lines.append(self.represent_multiline(indent=indent + 2,
@@ -303,7 +303,7 @@ class Step(Node):
         return '\n'.join(lines)
     # pylint:enable=too-many-arguments,arguments-differ
 
-    def represent_hashes(self, indent=6, **kwargs):
+    def represent_table(self, indent=6, **kwargs):
         """
         Render the table.
 

--- a/aloe/parser.py
+++ b/aloe/parser.py
@@ -275,7 +275,9 @@ class Step(Node):
 
         return max(
             0,
-            strings.get_terminal_width(self.represented(annotate=False)),
+            strings.get_terminal_width(self.represented(annotate=False,
+                                                        table=False,
+                                                        multiline=False)),
             *[strings.get_terminal_width(line)
               for line in self.represent_hashes().splitlines()]
         )

--- a/aloe/parser.py
+++ b/aloe/parser.py
@@ -280,12 +280,23 @@ class Step(Node):
               for line in self.represent_hashes().splitlines()]
         )
 
-    def represented(self, indent=4, annotate=True):
+    def represented(self, indent=4, annotate=True,
+                    table=True, multiline=True,
+                    color=str):
         """
         Render the line.
         """
 
-        return super().represented(indent=indent, annotate=annotate)
+        lines = [color(super().represented(indent=indent, annotate=annotate))]
+
+        if table and self.table:
+            lines.append(self.represent_hashes(indent=indent + 2,
+                                               cell_wrap=color))
+
+        if multiline and self.multiline:
+            pass  # FIXME
+
+        return '\n'.join(lines)
 
     def represent_hashes(self, indent=6, **kwargs):
         """

--- a/aloe/parser.py
+++ b/aloe/parser.py
@@ -297,7 +297,8 @@ class Step(Node):
                                                cell_wrap=color))
 
         if multiline and self.multiline:
-            pass  # FIXME
+            lines.append(self.represent_multiline(indent=indent + 2,
+                                                  string_wrap=color))
 
         return '\n'.join(lines)
     # pylint:enable=too-many-arguments,arguments-differ
@@ -305,9 +306,25 @@ class Step(Node):
     def represent_hashes(self, indent=6, **kwargs):
         """
         Render the table.
+
+        :param cell_wrap: color to use inside the table cells
         """
 
         return strings.represent_table(self.table, indent=indent, **kwargs)
+
+    def represent_multiline(self, indent=6, string_wrap=str):
+        """
+        Render the multiline.
+
+        :param string_wrap: color to use inside the string
+        """
+
+        lines = [' ' * indent + '"""']
+        lines += [' ' * indent + string_wrap(line)
+                  for line in self.multiline.splitlines()]
+        lines += [' ' * indent + '"""']
+
+        return '\n'.join(lines)
 
     def resolve_substitutions(self, outline):
         """

--- a/aloe/parser.py
+++ b/aloe/parser.py
@@ -282,6 +282,7 @@ class Step(Node):
               for line in self.represent_hashes().splitlines()]
         )
 
+    # pylint:disable=too-many-arguments,arguments-differ
     def represented(self, indent=4, annotate=True,
                     table=True, multiline=True,
                     color=str):
@@ -299,6 +300,7 @@ class Step(Node):
             pass  # FIXME
 
         return '\n'.join(lines)
+    # pylint:enable=too-many-arguments,arguments-differ
 
     def represent_hashes(self, indent=6, **kwargs):
         """

--- a/aloe/parser.py
+++ b/aloe/parser.py
@@ -555,7 +555,7 @@ class Description(Node):
 
     def represented(self, indent=2, annotate=True):
         return u'\n'.join(
-            self.represent_line(n)
+            self.represent_line(n, annotate=annotate)
             for n, _ in enumerate(self.lines)
         )
 

--- a/aloe/plugin.py
+++ b/aloe/plugin.py
@@ -115,7 +115,7 @@ class GherkinPlugin(Plugin):
         parser.add_option(
             '--color', action='store_true',
             dest='force_color',
-            default=None,
+            default=False,
             help='Force colored output',
         )
 

--- a/aloe/plugin.py
+++ b/aloe/plugin.py
@@ -234,6 +234,12 @@ class GherkinPlugin(Plugin):
             delattr(self, 'after_hook')
 
     def prepareTestRunner(self, runner):
+        """
+        Monkeypatch in our TestResult class.
+
+        In unittest we could just set runner.resultclass, but Nose
+        doesn't use this.
+        """
         def _makeResult(self):
             return AloeTestResult(self.stream,
                                   self.descriptions,

--- a/aloe/plugin.py
+++ b/aloe/plugin.py
@@ -112,6 +112,12 @@ class GherkinPlugin(Plugin):
             default='',
             help='Only run scenarios with these indices (comma-separated)',
         )
+        parser.add_option(
+            '--color', action='store_true',
+            dest='force_color',
+            default=None,
+            help='Force colored output',
+        )
 
         # Options for attribute plugin will be registered by its main instance
 
@@ -125,8 +131,9 @@ class GherkinPlugin(Plugin):
         module_name, class_name = options.test_class_name.rsplit('.', 1)
         module = import_module(module_name)
         self.test_class = getattr(module, class_name)
-
         self.ignore_python = options.ignore_python
+
+        conf.force_color = options.force_color
 
         if options.scenario_indices:
             self.scenario_indices = tuple(

--- a/aloe/plugin.py
+++ b/aloe/plugin.py
@@ -29,6 +29,7 @@ from future import standard_library
 standard_library.install_aliases()
 
 import os
+import types
 
 from importlib import import_module
 
@@ -38,6 +39,7 @@ from nose.plugins.attrib import AttributeSelector
 from aloe.fs import FeatureLoader
 from aloe.registry import CALLBACK_REGISTRY
 from aloe.testclass import TestCase
+from aloe.result import AloeTestResult
 
 
 class GherkinPlugin(Plugin):
@@ -230,3 +232,14 @@ class GherkinPlugin(Plugin):
         if hasattr(self, 'after_hook'):
             self.after_hook()
             delattr(self, 'after_hook')
+
+    def prepareTestRunner(self, runner):
+        def _makeResult(self):
+            return AloeTestResult(self.stream,
+                                  self.descriptions,
+                                  self.verbosity,
+                                  self.config)
+
+        runner._makeResult = types.MethodType(_makeResult, runner)
+
+        return runner

--- a/aloe/plugin.py
+++ b/aloe/plugin.py
@@ -29,7 +29,6 @@ from future import standard_library
 standard_library.install_aliases()
 
 import os
-import types
 
 from importlib import import_module
 
@@ -247,12 +246,13 @@ class GherkinPlugin(Plugin):
         In unittest we could just set runner.resultclass, but Nose
         doesn't use this.
         """
-        def _makeResult(self):
-            return AloeTestResult(self.stream,
-                                  self.descriptions,
-                                  self.verbosity,
-                                  self.config)
+        def _makeResult():
+            """Build our result"""
+            return AloeTestResult(runner.stream,
+                                  runner.descriptions,
+                                  runner.verbosity,
+                                  runner.config)
 
-        runner._makeResult = types.MethodType(_makeResult, runner)
+        runner._makeResult = _makeResult  # pylint:disable=protected-access
 
         return runner

--- a/aloe/registry.py
+++ b/aloe/registry.py
@@ -65,8 +65,8 @@ class PriorityClass(object):
     Priority class constants.
     """
 
-    DISPLAY = -20  # Display callbacks
-    SYSTEM_OUTER = -10  # System callbacks executing before others
+    DISPLAY = -20  # Display callbacks run first/last
+    SYSTEM_OUTER = -10  # System callbacks executing before all except DISPLAY
     USER = 0  # User callbacks
     SYSTEM_INNER = 10  # System callbacks executing after others
 

--- a/aloe/registry.py
+++ b/aloe/registry.py
@@ -65,6 +65,7 @@ class PriorityClass(object):
     Priority class constants.
     """
 
+    DISPLAY = -20  # Display callbacks
     SYSTEM_OUTER = -10  # System callbacks executing before others
     USER = 0  # User callbacks
     SYSTEM_INNER = 10  # System callbacks executing after others

--- a/aloe/result.py
+++ b/aloe/result.py
@@ -1,0 +1,35 @@
+# Aloe - Cucumber runner for Python based on Lettuce and Nose
+# Copyright (C) <2015> Danielle Madeley <danielle@madeley.id.au>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Cucumber-esque outputter for Nose.
+"""
+
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+# pylint:disable=redefined-builtin, unused-wildcard-import, wildcard-import
+from builtins import *
+# pylint:enable=redefined-builtin, unused-wildcard-import, wildcard-import
+from future import standard_library
+standard_library.install_aliases()
+
+from nose.result import TextTestResult
+
+
+class AloeTestResult(TextTestResult):
+    pass

--- a/aloe/result.py
+++ b/aloe/result.py
@@ -58,15 +58,11 @@ class StreamWrapper(object):
 
         return getattr(self.term.stream, attr)
 
-    def write(self, arg=None, return_=False):
-        if not self.term:
-            return
+    def write(self, arg='', return_=False):
+        self.term.stream.write(arg)
 
-        elif arg:
-            self.term.stream.write(arg)
-
-            if return_:
-                self.term.stream.write(self.term.move_up * arg.count('\n'))
+        if return_:
+            self.term.stream.write(self.term.move_up * arg.count('\n'))
 
     def writeln(self, arg='', return_=False):
         self.write(arg + '\n', return_=return_)
@@ -79,6 +75,10 @@ StreamWrapper = StreamWrapper(None)
 @contextmanager
 def feature_wrapper(feature):
     term = StreamWrapper.term
+
+    if not term:
+        yield
+        return
 
     try:
         if feature.tags:
@@ -100,6 +100,10 @@ def feature_wrapper(feature):
 def example_wrapper(scenario, outline, steps):
     """Display scenario execution."""
     term = StreamWrapper.term
+
+    if not term:
+        yield
+        return
 
     try:
         if scenario.tags:
@@ -140,6 +144,10 @@ def example_wrapper(scenario, outline, steps):
 def step_wrapper(step):
     """Display step execution."""
     term = StreamWrapper.term
+
+    if not term:
+        yield
+        return
 
     try:
         if term.does_styling:

--- a/aloe/result.py
+++ b/aloe/result.py
@@ -55,6 +55,7 @@ class StreamWrapper(object):
     def __getattr__(self, attr):
         if attr in ('term', '__getstate__'):
             raise AttributeError(attr)
+
         return getattr(self.term.stream, attr)
 
     def write(self, arg=None, return_=False):

--- a/aloe/result.py
+++ b/aloe/result.py
@@ -125,7 +125,7 @@ def example_wrapper(scenario, outline, steps):
             StreamWrapper.writeln()
 
         # write a preview of the steps
-        if term.does_styling:
+        if term.is_a_tty:
             StreamWrapper.writeln(
                 gray('\n'.join(
                     step.represented(annotate=False)
@@ -150,7 +150,7 @@ def step_wrapper(step):
         return
 
     try:
-        if term.does_styling:
+        if term.is_a_tty:
             StreamWrapper.writeln(
                 step.represented(annotate=False, color=term.color(11)),
                 return_=True)

--- a/aloe/result.py
+++ b/aloe/result.py
@@ -32,4 +32,25 @@ from nose.result import TextTestResult
 
 
 class AloeTestResult(TextTestResult):
-    pass
+    def __init__(self, stream, descriptions, verbosity,
+                 config=None, errorClasses=None):
+        super().__init__(stream, descriptions, verbosity,
+                         config=config, errorClasses=errorClasses)
+        print("Verbosity", verbosity)
+        self.showAll = verbosity == 2
+        self.showSteps = verbosity > 2
+
+    def startTest(self, test):
+        super().startTest(test)
+        if self.showSteps:
+            self.stream.writeln("Starting test %s" % test)
+
+    def stopTest(self, test):
+        super().stopTest(test)
+        if self.showSteps:
+            self.stream.writeln("Stopping test %s" % test)
+
+    def addSuccess(self, test):
+        super().addSuccess(test)
+        if self.showSteps:
+            self.stream.writeln("BOO YAH")

--- a/aloe/result.py
+++ b/aloe/result.py
@@ -35,6 +35,7 @@ from aloe.registry import (
     CALLBACK_REGISTRY,
     PriorityClass,
 )
+from aloe.strings import represent_table
 from blessings import Terminal
 from nose.result import TextTestResult
 
@@ -116,6 +117,13 @@ def example_wrapper(scenario, outline, steps):
         StreamWrapper.write(term.bold_white(start))
         StreamWrapper.writeln(gray(end))
 
+        if outline:
+            StreamWrapper.writeln(represent_table([outline.keys(),
+                                                   outline.values()],
+                                                  indent=6,
+                                                  cell_wrap=term.white))
+            StreamWrapper.writeln()
+
         # write a preview of the steps
         if term.does_styling:
             StreamWrapper.writeln(
@@ -138,11 +146,9 @@ def step_wrapper(step):
 
     try:
         if term.does_styling:
-            lines = step.represented(annotate=False)
-            if step.table:
-                lines += step.represent_hashes()
-
-            StreamWrapper.writeln(term.color(11)(lines), return_=True)
+            StreamWrapper.writeln(
+                step.represented(annotate=False, color=term.color(11)),
+                return_=True)
 
         yield
     finally:
@@ -153,9 +159,9 @@ def step_wrapper(step):
         else:
             color = term.yellow
 
-        StreamWrapper.writeln(color(step.represented(annotate=False)))
-        if step.table:
-            StreamWrapper.writeln(color(step.represent_hashes()))
+        StreamWrapper.writeln(
+            step.represented(annotate=False, color=color)
+        )
 
 
 class AloeTestResult(TextTestResult):

--- a/aloe/result.py
+++ b/aloe/result.py
@@ -143,11 +143,17 @@ def example_wrapper(scenario, outline, steps):
 @contextmanager
 def step_wrapper(step):
     """Display step execution."""
+
     term = StreamWrapper.term
 
-    if not term:
+    # if we don't have a term, that means the v3 level outputter isn't
+    # enabled; also
+    # don't reenter, which will happen if someone called step.behave_as
+    if not term or step_wrapper.entered:
         yield
         return
+
+    step_wrapper.entered = True
 
     try:
         if term.is_a_tty:
@@ -167,6 +173,10 @@ def step_wrapper(step):
         StreamWrapper.writeln(
             step.represented(annotate=False, color=color)
         )
+
+        step_wrapper.entered = False
+
+step_wrapper.entered = False
 
 
 class AloeTestResult(TextTestResult):

--- a/aloe/result.py
+++ b/aloe/result.py
@@ -129,10 +129,17 @@ def example_wrapper(scenario, outline, steps):
 
         # write a preview of the steps
         if term.is_a_tty:
+            steps_ = []
+
+            if scenario.feature.background:
+                steps_ += scenario.feature.background.steps
+
+            steps_ += steps
+
             STREAM_WRAPPER.writeln(
                 gray('\n'.join(
                     step.represented(annotate=False)
-                    for step in steps
+                    for step in steps_
                 ) + '\n'),
                 return_=True
             )

--- a/aloe/strings.py
+++ b/aloe/strings.py
@@ -33,7 +33,7 @@ standard_library.install_aliases()
 import unicodedata
 
 
-def represent_table(table, indent=0, cell_wrap=lambda s: s):
+def represent_table(table, indent=0, cell_wrap=str):
     """
     Render a table
 

--- a/aloe/testing.py
+++ b/aloe/testing.py
@@ -186,6 +186,8 @@ class TestGherkinPlugin(GherkinPlugin):
 class TestRunner(Runner):
     """
     A test test runner to store information about the tests run.
+
+    :param stream: pass your a stream to write the output into
     """
 
     def gherkin_plugin(self):

--- a/aloe/testing.py
+++ b/aloe/testing.py
@@ -225,7 +225,9 @@ class FeatureTest(unittest.TestCase):
             feature_file.flush()
             return self.run_features(os.path.relpath(feature_file.name))
 
-    def run_features(self, *features, verbosity=None):
+    def run_features(self, *features,
+                     verbosity=None,
+                     force_color=False):
         """
         Run the specified features.
         """
@@ -238,6 +240,9 @@ class FeatureTest(unittest.TestCase):
 
         if verbosity:
             argv += ['--verbosity', str(verbosity)]
+
+        if force_color:
+            argv += ['--color']
 
         argv += list(features)
 

--- a/aloe/testing.py
+++ b/aloe/testing.py
@@ -199,7 +199,14 @@ class TestRunner(Runner):
 
     def __init__(self, *args, **kwargs):
         self.tests_run = []
+        self.stream = kwargs.pop('stream')
+
         super().__init__(*args, **kwargs)
+
+    def makeConfig(self, *args, **kwargs):
+        config = super().makeConfig(*args, **kwargs)
+        config.stream = self.stream
+        return config
 
 
 class FeatureTest(unittest.TestCase):
@@ -227,6 +234,7 @@ class FeatureTest(unittest.TestCase):
 
     def run_features(self, *features,
                      verbosity=None,
+                     stream=None,
                      force_color=False):
         """
         Run the specified features.
@@ -246,7 +254,7 @@ class FeatureTest(unittest.TestCase):
 
         argv += list(features)
 
-        return TestRunner(exit=False, argv=argv)
+        return TestRunner(exit=False, argv=argv, stream=stream)
 
     def assert_feature_success(self, *features):
         """

--- a/aloe/testing.py
+++ b/aloe/testing.py
@@ -187,7 +187,7 @@ class TestRunner(Runner):
     """
     A test test runner to store information about the tests run.
 
-    :param stream: pass your a stream to write the output into
+    :param stream: a stream to write the output into (optional)
     """
 
     def gherkin_plugin(self):

--- a/aloe/testing.py
+++ b/aloe/testing.py
@@ -232,13 +232,14 @@ class FeatureTest(unittest.TestCase):
             feature_file.flush()
             return self.run_features(os.path.relpath(feature_file.name))
 
-    def run_features(self, *features,
-                     verbosity=None,
-                     stream=None,
-                     force_color=False):
+    def run_features(self, *features, **kwargs):
         """
         Run the specified features.
         """
+
+        verbosity = kwargs.get('verbosity')
+        stream = kwargs.get('stream')
+        force_color=kwargs.get('force_color', False)
 
         CALLBACK_REGISTRY.clear(priority_class=PriorityClass.USER)
         STEP_REGISTRY.clear()

--- a/aloe/testing.py
+++ b/aloe/testing.py
@@ -225,7 +225,7 @@ class FeatureTest(unittest.TestCase):
             feature_file.flush()
             return self.run_features(os.path.relpath(feature_file.name))
 
-    def run_features(self, *features):
+    def run_features(self, *features, verbosity=None):
         """
         Run the specified features.
         """
@@ -234,8 +234,14 @@ class FeatureTest(unittest.TestCase):
         STEP_REGISTRY.clear()
         world.__dict__.clear()
 
-        return TestRunner(exit=False,
-                          argv=['aloe'] + list(features))
+        argv = ['aloe']
+
+        if verbosity:
+            argv += ['--verbosity', str(verbosity)]
+
+        argv += list(features)
+
+        return TestRunner(exit=False, argv=argv)
 
     def assert_feature_success(self, *features):
         """

--- a/aloe/testing.py
+++ b/aloe/testing.py
@@ -205,7 +205,10 @@ class TestRunner(Runner):
 
     def makeConfig(self, *args, **kwargs):
         config = super().makeConfig(*args, **kwargs)
-        config.stream = self.stream
+
+        if self.stream:
+            config.stream = self.stream
+
         return config
 
 
@@ -239,7 +242,7 @@ class FeatureTest(unittest.TestCase):
 
         verbosity = kwargs.get('verbosity')
         stream = kwargs.get('stream')
-        force_color=kwargs.get('force_color', False)
+        force_color = kwargs.get('force_color', False)
 
         CALLBACK_REGISTRY.clear(priority_class=PriorityClass.USER)
         STEP_REGISTRY.clear()

--- a/aloe/tools.py
+++ b/aloe/tools.py
@@ -97,12 +97,6 @@ def guess_types(data):  # pylint:disable=too-complex
     return data
 
 
-def _empty_generator(*args, **kwargs):
-    """An empty generator suitable to replace a context manager"""
-    yield
-    return
-
-
 def hook_not_reentrant(func):
     """
     Decorate a hook as unable to be reentered while it is already in the
@@ -132,18 +126,12 @@ def hook_not_reentrant(func):
             because Python 2 can't support "returning from generators"
             """
             if func._entered:
-                gen = _empty_generator()
-
-                yield next(gen)
-                next(gen)
-                return
+                yield
             else:
                 try:
                     func._entered = True
-                    gen = func(*args, **kwargs)
-                    yield next(gen)
-                    next(gen)
-                    return
+                    for val in func(*args, **kwargs):
+                        yield val
                 finally:
                     func._entered = False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
+blessings
 future
 nose
 pyparsing
-blessings

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 future
 nose
 pyparsing
+blessings

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,6 @@
 coverage
+factory_boy
+mock
 pep8
 pylint
 pylint-mccabe
-factory_boy
-mock

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,3 +3,4 @@ pep8
 pylint
 pylint-mccabe
 factory_boy
+mock

--- a/tests/functional/test_outputter.py
+++ b/tests/functional/test_outputter.py
@@ -1,0 +1,47 @@
+# Aloe - Cucumber runner for Python based on Lettuce and Nose
+# Copyright (C) <2015> Danielle Madeley <danielle@madeley.id.au>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Test level 3 outputter
+"""
+
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+# pylint:disable=redefined-builtin, unused-wildcard-import, wildcard-import
+from builtins import *
+# pylint:enable=redefined-builtin, unused-wildcard-import, wildcard-import
+from future import standard_library
+standard_library.install_aliases()
+
+from aloe.testing import (
+    FeatureTest,
+    in_directory,
+)
+
+
+@in_directory('tests/simple_app')
+class OutputterTest(FeatureTest):
+    """
+    Test level 3 outputter
+    """
+
+    def test_outputter(self):
+        """
+        Test Factory Boy steps.
+        """
+
+        self.assert_feature_success('--verbosity=3',  # HACKY
+                                    'features/calculator.feature')

--- a/tests/functional/test_outputter.py
+++ b/tests/functional/test_outputter.py
@@ -44,4 +44,4 @@ class OutputterTest(FeatureTest):
         """
 
         self.assert_feature_success('--verbosity=3',  # HACKY
-                                    'features/scenario_index.feature')
+                                    'features/highlighting.feature')

--- a/tests/functional/test_outputter.py
+++ b/tests/functional/test_outputter.py
@@ -126,6 +126,13 @@ Feature: Highlighting
       | 1     |
       | 2     |
 
+  Scenario: Scenario with a multiline                  features/highlighting.feature:32
+    Given I have a table
+    Given I have a table:
+      \"\"\"
+      Not actually a table :-P
+      \"\"\"
+
 """.lstrip())  # noqa
 
     def test_color_output(self):
@@ -179,6 +186,13 @@ t.bold_green(Given I have a table:)
       | t.bold_green(1) |
       | t.bold_green(1) |
       | t.bold_green(2) |
+
+t.bold_white(Scenario: Scenario with a multiline)t.color8(features/highlighting.feature:32)
+t.bold_green(Given I have a table)
+t.bold_green(Given I have a table:)
+      \"\"\"
+      t.bold_green(Not actually a table :-P)
+      \"\"\"
 
 """.lstrip())  # noqa
 

--- a/tests/functional/test_outputter.py
+++ b/tests/functional/test_outputter.py
@@ -105,25 +105,29 @@ Feature: Scenario indices
   I want to see my scenarios with pretty highlighting
   So my output is easy to read
 
-  Scenario: behave_as works                            features/highlighting.feature:9
+  Scenario: behave_as works                            features/highlighting.feature:12
+    Given I have a table
     Given I have entered 10 into the calculator
     And I press [+]
 
-  Scenario Outline: Scenario outlines                  features/highlighting.feature:13
+  Scenario Outline: Scenario outlines                  features/highlighting.feature:16
       | number |
       | 30     |
 
+    Given I have a table
     Given I have entered <number> into the calculator
     And I press add
 
-  Scenario Outline: Scenario outlines                  features/highlighting.feature:13
+  Scenario Outline: Scenario outlines                  features/highlighting.feature:16
       | number |
       | 40     |
 
+    Given I have a table
     Given I have entered <number> into the calculator
     And I press add
 
-  Scenario: Scenario with table                        features/highlighting.feature:22
+  Scenario: Scenario with table                        features/highlighting.feature:25
+    Given I have a table
     Given I have a table:
       | value |
       | 1     |
@@ -154,25 +158,29 @@ t.white(As a programmer
   I want to see my scenarios with pretty highlighting
   So my output is easy to read)
 
-t.bold_white(Scenario: behave_as works)t.color8(features/highlighting.feature:9)
+t.bold_white(Scenario: behave_as works)t.color8(features/highlighting.feature:12)
+t.bold_green(Given I have a table)
 t.bold_green(Given I have entered 10 into the calculator)
 t.bold_green(And I press [+])
 
-t.bold_white(Scenario Outline: Scenario outlines)t.color8(features/highlighting.feature:13)
+t.bold_white(Scenario Outline: Scenario outlines)t.color8(features/highlighting.feature:16)
       | t.white(number) |
       | t.white(30) |
 
+t.bold_green(Given I have a table)
 t.bold_green(Given I have entered <number> into the calculator)
 t.bold_green(And I press add)
 
-t.bold_white(Scenario Outline: Scenario outlines)t.color8(features/highlighting.feature:13)
+t.bold_white(Scenario Outline: Scenario outlines)t.color8(features/highlighting.feature:16)
       | t.white(number) |
       | t.white(40) |
 
+t.bold_green(Given I have a table)
 t.bold_green(Given I have entered <number> into the calculator)
 t.bold_green(And I press add)
 
-t.bold_white(Scenario: Scenario with table)t.color8(features/highlighting.feature:22)
+t.bold_white(Scenario: Scenario with table)t.color8(features/highlighting.feature:25)
+t.bold_green(Given I have a table)
 t.bold_green(Given I have a table:)
       | t.bold_green(value) |
       | t.bold_green(1) |
@@ -208,10 +216,13 @@ t.white(As a programmer
   I want to see my scenarios with pretty highlighting
   So my output is easy to read)
 
-t.bold_white(Scenario: behave_as works)t.color8(features/highlighting.feature:9)
-t.color8(Given I have entered 10 into the calculator
+t.bold_white(Scenario: behave_as works)t.color8(features/highlighting.feature:12)
+t.color8(Given I have a table
+    Given I have entered 10 into the calculator
     And I press [+])
-<t.move_up><t.move_up>t.color11(Given I have entered 10 into the calculator)
+<t.move_up><t.move_up><t.move_up>t.color11(Given I have a table)
+<t.move_up>t.bold_green(Given I have a table)
+t.color11(Given I have entered 10 into the calculator)
 <t.move_up>t.bold_green(Given I have entered 10 into the calculator)
 t.color11(And I press [+])
 <t.move_up>t.bold_green(And I press [+])

--- a/tests/functional/test_outputter.py
+++ b/tests/functional/test_outputter.py
@@ -35,8 +35,14 @@ from aloe.testing import (
 from mock import patch
 
 
-class TermElement(object):
-    """A colourful element being output by the mock terminal"""
+class MockTermElement(object):
+    """
+    Wraps a element being output by the MockTerminal (i.e. term.bold) and
+    replaces it with a string that can be checked in tests.
+
+    Like with the attributes in Terminal it can be used as a callable or
+    a string.
+    """
     def __init__(self, attr):
         self.attr = attr
 
@@ -53,7 +59,12 @@ class TermElement(object):
 
 
 class MockTerminal(object):
-    """A mock of the blessings.Terminal class"""
+    """
+    A mock of the blessings.Terminal class.
+
+    Allows control over whether or not the terminal is a tty and emits all
+    terminal control codes as strings.
+    """
 
     is_a_tty = False
 
@@ -70,7 +81,7 @@ class MockTerminal(object):
             raise AttributeError(attr)
 
         # callable factory
-        return TermElement(attr)
+        return MockTermElement(attr)
 
     def color(self, color):
         """Return a color callable"""

--- a/tests/functional/test_outputter.py
+++ b/tests/functional/test_outputter.py
@@ -38,7 +38,7 @@ from mock import patch
 
 class MockTermElement(object):
     """
-    Wraps a element being output by the MockTerminal (i.e. term.bold) and
+    Wraps an element being output by the MockTerminal (i.e. term.bold) and
     replaces it with a string that can be checked in tests.
 
     Like with the attributes in Terminal it can be used as a callable or
@@ -65,7 +65,7 @@ class MockOutputTerminal(OutputTerminal):
     def __getattr__(self, attr):
         return MockTermElement(attr)
 
-    def color(self, color):  # pylint:disable=arguments-differ
+    def color(self, color):
         return getattr(self, 'color%s' % color)
 
 

--- a/tests/functional/test_outputter.py
+++ b/tests/functional/test_outputter.py
@@ -26,6 +26,7 @@ from builtins import *
 from future import standard_library
 standard_library.install_aliases()
 
+from io import StringIO
 from aloe.testing import (
     FeatureTest,
     in_directory,
@@ -38,10 +39,75 @@ class OutputterTest(FeatureTest):
     Test level 3 outputter
     """
 
-    def test_outputter(self):
-        """
-        Test Factory Boy steps.
-        """
+    maxDiff = None
 
-        self.run_features('features/highlighting.feature',
-                          verbosity=3)
+    def test_output(self):
+        """Test streamed output"""
+
+        with StringIO() as stream:
+            self.run_features('features/highlighting.feature',
+                              verbosity=3, stream=stream)
+
+            print("--Output--")
+            print(stream.getvalue())
+            print("--END--")
+
+            # FIXME: where do these right alignments come from?
+            self.assertEqual(stream.getvalue(), """
+Feature: Scenario indices
+
+  As a programmer
+  I want to see my scenarios with pretty highlighting
+  So my output is easy to read
+
+  Scenario: First scenario                                                              features/highlighting.feature:9
+    Given I have entered 10 into the calculator
+    And I press add
+
+  Scenario Outline: Scenario outline with two examples                                  features/highlighting.feature:13
+      | number |
+      | 30     |
+
+    Given I have entered <number> into the calculator
+    And I press add
+
+  Scenario Outline: Scenario outline with two examples                                  features/highlighting.feature:13
+      | number |
+      | 40     |
+
+    Given I have entered <number> into the calculator
+    And I press add
+
+  Scenario: Scenario with table                                                         features/highlighting.feature:22
+    Given I press add:
+      | value |
+      | 1     |
+      | 1     |
+      | 2     |
+
+----------------------------------------------------------------------
+Ran 3 tests in 0.003s
+
+OK
+""".lstrip())
+
+    def test_color_output(self):
+        """Test streamed output with color"""
+
+        with StringIO() as stream:
+            self.run_features('features/highlighting.feature',
+                              verbosity=3, stream=stream,
+                              force_color=True)
+
+            print("--Output--")
+            print(stream.getvalue())
+            print("--END--")
+
+            self.assertEqual(stream.getvalue(), """
+Feature: Scenario indices
+
+  As a programmer
+  I want to see my scenarios with pretty highlighting
+  So my output is easy to read
+
+""".lstrip())

--- a/tests/functional/test_outputter.py
+++ b/tests/functional/test_outputter.py
@@ -26,7 +26,10 @@ from builtins import *
 from future import standard_library
 standard_library.install_aliases()
 
-from unittest.mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from io import StringIO
 from aloe.testing import (
@@ -65,7 +68,8 @@ class MockTerminal(object):
         if attr in ('stream',
                     'does_styling',
                     'is_a_tty',
-                    '__getstate__'):
+                    '__getstate__',
+                    '__bool__'):
             raise AttributeError(attr)
 
         # callable factory

--- a/tests/functional/test_outputter.py
+++ b/tests/functional/test_outputter.py
@@ -32,7 +32,7 @@ from aloe.testing import (
     FeatureTest,
     in_directory,
 )
-from aloe.result import OutputTerminal
+from aloe.result import Terminal
 from mock import patch
 
 
@@ -59,7 +59,7 @@ class MockTermElement(object):
         return str(self) * other
 
 
-class MockOutputTerminal(OutputTerminal):
+class MockTerminal(Terminal):
     """Mock terminal to output printable elements instead of ANSI sequences"""
 
     def __getattr__(self, attr):
@@ -139,8 +139,7 @@ Feature: Highlighting
         """Test streamed output with color"""
 
         with \
-                patch('aloe.result.OutputTerminal',
-                      new=MockOutputTerminal), \
+                patch('aloe.result.Terminal', new=MockTerminal), \
                 patch('aloe.result.AloeTestResult.printSummary'), \
                 StringIO() as stream:
             self.run_features('features/highlighting.feature',
@@ -200,8 +199,7 @@ t.bold_green(Given I have a table:)
         """Test streamed output with tty control codes"""
 
         with \
-                patch('aloe.result.OutputTerminal',
-                      new=MockOutputTerminal) as mock_term, \
+                patch('aloe.result.Terminal', new=MockTerminal) as mock_term, \
                 patch('aloe.result.AloeTestResult.printSummary'), \
                 StringIO() as stream:
 

--- a/tests/functional/test_outputter.py
+++ b/tests/functional/test_outputter.py
@@ -43,5 +43,5 @@ class OutputterTest(FeatureTest):
         Test Factory Boy steps.
         """
 
-        self.assert_feature_success('--verbosity=3',  # HACKY
-                                    'features/highlighting.feature')
+        self.run_features('features/highlighting.feature',
+                          verbosity=3)

--- a/tests/functional/test_outputter.py
+++ b/tests/functional/test_outputter.py
@@ -26,16 +26,13 @@ from builtins import *
 from future import standard_library
 standard_library.install_aliases()
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
 from io import StringIO
+
 from aloe.testing import (
     FeatureTest,
     in_directory,
 )
+from mock import patch
 
 
 class TermElement(object):

--- a/tests/functional/test_outputter.py
+++ b/tests/functional/test_outputter.py
@@ -91,7 +91,7 @@ class OutputterTest(FeatureTest):
             print("--END--")
 
             self.assertEqual(stream.getvalue(), """
-Feature: Scenario indices
+Feature: Highlighting
 
   As a programmer
   I want to see my scenarios with pretty highlighting
@@ -145,7 +145,7 @@ Feature: Scenario indices
             print("--END--")
 
             self.assertEqual(stream.getvalue(), """
-t.bold_white(Feature: Scenario indices)
+t.bold_white(Feature: Highlighting)
 
 t.white(As a programmer
   I want to see my scenarios with pretty highlighting
@@ -204,7 +204,7 @@ t.bold_green(Given I have a table:)
             # once in color 8 as a preview, then each line individually
             # followed by a green version of it
             self.assertEqual(stream.getvalue(), """
-t.bold_white(Feature: Scenario indices)
+t.bold_white(Feature: Highlighting)
 
 t.white(As a programmer
   I want to see my scenarios with pretty highlighting

--- a/tests/functional/test_outputter.py
+++ b/tests/functional/test_outputter.py
@@ -36,12 +36,14 @@ from aloe.testing import (
 
 
 class TermElement(object):
+    """A colourful element being output by the mock terminal"""
     def __init__(self, attr):
         self.attr = attr
 
-    def __call__(self, s):
+    def __call__(self, str_):
         # strips the string to make the output easier to read
-        return 't.{attr}({s})'.format(attr=self.attr, s=s.strip())
+        return 't.{attr}({str})'.format(attr=self.attr,
+                                        str=str_.strip())
 
     def __str__(self):
         return '<t.{attr}>'.format(attr=self.attr)
@@ -51,6 +53,7 @@ class TermElement(object):
 
 
 class MockTerminal(object):
+    """A mock of the blessings.Terminal class"""
 
     is_a_tty = False
 
@@ -69,6 +72,7 @@ class MockTerminal(object):
         return TermElement(attr)
 
     def color(self, color):
+        """Return a color callable"""
 
         return getattr(self, 'color%s' % color)
 
@@ -126,7 +130,7 @@ Feature: Scenario indices
       | 1     |
       | 2     |
 
-""".lstrip())
+""".lstrip())  # noqa
 
     def test_color_output(self):
         """Test streamed output with color"""
@@ -175,7 +179,7 @@ t.bold_green(Given I have a table:)
       | t.bold_green(1) |
       | t.bold_green(2) |
 
-""".lstrip())
+""".lstrip())  # noqa
 
     def test_tty_output(self):
         """Test streamed output with tty control codes"""
@@ -212,4 +216,4 @@ t.color8(Given I have entered 10 into the calculator
 t.color11(And I press [+])
 <t.move_up>t.bold_green(And I press [+])
 
-""".lstrip())
+""".lstrip())  # noqa

--- a/tests/functional/test_outputter.py
+++ b/tests/functional/test_outputter.py
@@ -91,7 +91,6 @@ class OutputterTest(FeatureTest):
             print(stream.getvalue())
             print("--END--")
 
-            # FIXME: where do these right alignments come from?
             self.assertEqual(stream.getvalue(), """
 Feature: Scenario indices
 
@@ -99,25 +98,25 @@ Feature: Scenario indices
   I want to see my scenarios with pretty highlighting
   So my output is easy to read
 
-  Scenario: First scenario                                                              features/highlighting.feature:9
+  Scenario: First scenario                              features/highlighting.feature:9
     Given I have entered 10 into the calculator
     And I press add
 
-  Scenario Outline: Scenario outline with two examples                                  features/highlighting.feature:13
+  Scenario Outline: Scenario outline with two examples  features/highlighting.feature:13
       | number |
       | 30     |
 
     Given I have entered <number> into the calculator
     And I press add
 
-  Scenario Outline: Scenario outline with two examples                                  features/highlighting.feature:13
+  Scenario Outline: Scenario outline with two examples  features/highlighting.feature:13
       | number |
       | 40     |
 
     Given I have entered <number> into the calculator
     And I press add
 
-  Scenario: Scenario with table                                                         features/highlighting.feature:22
+  Scenario: Scenario with table                         features/highlighting.feature:22
     Given I press add:
       | value |
       | 1     |

--- a/tests/functional/test_outputter.py
+++ b/tests/functional/test_outputter.py
@@ -44,4 +44,4 @@ class OutputterTest(FeatureTest):
         """
 
         self.assert_feature_success('--verbosity=3',  # HACKY
-                                    'features/calculator.feature')
+                                    'features/scenario_index.feature')

--- a/tests/functional/test_outputter.py
+++ b/tests/functional/test_outputter.py
@@ -26,11 +26,48 @@ from builtins import *
 from future import standard_library
 standard_library.install_aliases()
 
+from unittest.mock import patch
+
 from io import StringIO
 from aloe.testing import (
     FeatureTest,
     in_directory,
 )
+
+
+class TermElement(object):
+    def __init__(self, attr):
+        self.attr = attr
+
+    def __call__(self, s):
+        # strips the string to make the output easier to read
+        return 't.{attr}({s})'.format(attr=self.attr, s=s.strip())
+
+    def __str__(self):
+        return '<t.{attr}>'.format(attr=self.attr)
+
+    def __mul__(self, other):
+        return str(self) * other
+
+
+class MockTerminal(object):
+
+    def __init__(self, stream, force_styling=None):
+        self.stream = stream
+        self.does_styling = True
+
+    def __getattr__(self, attr):
+        if attr in ('stream',
+                    'does_styling',
+                    '__getstate__'):
+            raise AttributeError(attr)
+
+        # callable factory
+        return TermElement(attr)
+
+    def color(self, color):
+
+        return getattr(self, 'color%s' % color)
 
 
 @in_directory('tests/simple_app')
@@ -44,7 +81,9 @@ class OutputterTest(FeatureTest):
     def test_output(self):
         """Test streamed output"""
 
-        with StringIO() as stream:
+        with \
+                StringIO() as stream, \
+                patch('aloe.result.AloeTestResult.printSummary'):
             self.run_features('features/highlighting.feature',
                               verbosity=3, stream=stream)
 
@@ -85,16 +124,15 @@ Feature: Scenario indices
       | 1     |
       | 2     |
 
-----------------------------------------------------------------------
-Ran 3 tests in 0.003s
-
-OK
 """.lstrip())
 
     def test_color_output(self):
         """Test streamed output with color"""
 
-        with StringIO() as stream:
+        with \
+                patch('aloe.result.Terminal', new=MockTerminal), \
+                patch('aloe.result.AloeTestResult.printSummary'), \
+                StringIO() as stream:
             self.run_features('features/highlighting.feature',
                               verbosity=3, stream=stream,
                               force_color=True)
@@ -104,10 +142,57 @@ OK
             print("--END--")
 
             self.assertEqual(stream.getvalue(), """
-Feature: Scenario indices
+t.bold_white(Feature: Scenario indices)
 
-  As a programmer
+t.white(As a programmer
   I want to see my scenarios with pretty highlighting
-  So my output is easy to read
+  So my output is easy to read)
+
+t.bold_white(Scenario: First scenario)t.color8(features/highlighting.feature:9)
+t.color8(Given I have entered 10 into the calculator
+    And I press add)
+<t.move_up><t.move_up>t.color11(Given I have entered 10 into the calculator)
+<t.move_up>t.bold_green(Given I have entered 10 into the calculator)
+t.color11(And I press add)
+<t.move_up>t.bold_green(And I press add)
+
+t.bold_white(Scenario Outline: Scenario outline with two examples)t.color8(features/highlighting.feature:13)
+      | t.white(number) |
+      | t.white(30) |
+
+t.color8(Given I have entered <number> into the calculator
+    And I press add)
+<t.move_up><t.move_up>t.color11(Given I have entered <number> into the calculator)
+<t.move_up>t.bold_green(Given I have entered <number> into the calculator)
+t.color11(And I press add)
+<t.move_up>t.bold_green(And I press add)
+
+t.bold_white(Scenario Outline: Scenario outline with two examples)t.color8(features/highlighting.feature:13)
+      | t.white(number) |
+      | t.white(40) |
+
+t.color8(Given I have entered <number> into the calculator
+    And I press add)
+<t.move_up><t.move_up>t.color11(Given I have entered <number> into the calculator)
+<t.move_up>t.bold_green(Given I have entered <number> into the calculator)
+t.color11(And I press add)
+<t.move_up>t.bold_green(And I press add)
+
+t.bold_white(Scenario: Scenario with table)t.color8(features/highlighting.feature:22)
+t.color8(Given I press add:
+      | value |
+      | 1     |
+      | 1     |
+      | 2     |)
+<t.move_up><t.move_up><t.move_up><t.move_up><t.move_up>t.color11(Given I press add:)
+      | t.color11(value) |
+      | t.color11(1) |
+      | t.color11(1) |
+      | t.color11(2) |
+<t.move_up><t.move_up><t.move_up><t.move_up><t.move_up>t.bold_green(Given I press add:)
+      | t.bold_green(value) |
+      | t.bold_green(1) |
+      | t.bold_green(1) |
+      | t.bold_green(2) |
 
 """.lstrip())

--- a/tests/simple_app/features/highlighting.feature
+++ b/tests/simple_app/features/highlighting.feature
@@ -1,0 +1,27 @@
+Feature: Scenario indices
+
+  As a programmer
+  I want to see my scenarios with pretty highlighting
+  So my output is easy to read
+
+  # Comments are not shown
+
+  Scenario: First scenario
+    Given I have entered 10 into the calculator
+    And I press add
+
+  Scenario Outline: Scenario outline with two examples
+    Given I have entered <number> into the calculator
+    And I press add
+
+    Examples:
+      | number |
+      | 30     |
+      | 40     |
+
+  Scenario: Scenario with table
+    Given I press add:
+      | value |
+      | 1     |
+      | 1     |
+      | 2     |

--- a/tests/simple_app/features/highlighting.feature
+++ b/tests/simple_app/features/highlighting.feature
@@ -1,4 +1,4 @@
-Feature: Scenario indices
+Feature: Highlighting
 
   As a programmer
   I want to see my scenarios with pretty highlighting

--- a/tests/simple_app/features/highlighting.feature
+++ b/tests/simple_app/features/highlighting.feature
@@ -28,3 +28,9 @@ Feature: Highlighting
       | 1     |
       | 1     |
       | 2     |
+
+  Scenario: Scenario with a multiline
+    Given I have a table:
+    """
+    Not actually a table :-P
+    """

--- a/tests/simple_app/features/highlighting.feature
+++ b/tests/simple_app/features/highlighting.feature
@@ -6,6 +6,9 @@ Feature: Scenario indices
 
   # Comments are not shown
 
+  Background:
+    Given I have a table
+
   Scenario: behave_as works
     Given I have entered 10 into the calculator
     And I press [+]

--- a/tests/simple_app/features/highlighting.feature
+++ b/tests/simple_app/features/highlighting.feature
@@ -6,11 +6,11 @@ Feature: Scenario indices
 
   # Comments are not shown
 
-  Scenario: First scenario
+  Scenario: behave_as works
     Given I have entered 10 into the calculator
-    And I press add
+    And I press [+]
 
-  Scenario Outline: Scenario outline with two examples
+  Scenario Outline: Scenario outlines
     Given I have entered <number> into the calculator
     And I press add
 
@@ -20,7 +20,7 @@ Feature: Scenario indices
       | 40     |
 
   Scenario: Scenario with table
-    Given I press add:
+    Given I have a table:
       | value |
       | 1     |
       | 1     |

--- a/tests/simple_app/features/steps.py
+++ b/tests/simple_app/features/steps.py
@@ -55,6 +55,17 @@ def press_add(self):
     world.result = sum(world.numbers)
 
 
+@step(r'I press \[\+\]')
+def press_plus(self):
+    """Test behave_as"""
+    self.given('I press add')
+
+
+@step(r'I have a table')
+def press_add(self):
+    """Nothing."""
+
+
 @step(r'The result should be (\d+) on the screen')
 def assert_result(self, result):
     """Assert the result is correct."""

--- a/tests/simple_app/features/steps.py
+++ b/tests/simple_app/features/steps.py
@@ -57,7 +57,11 @@ def press_add(self):
 
 @step(r'I press \[\+\]')
 def press_plus(self):
-    """Test behave_as"""
+    """
+    Alias of 'I press add'.
+
+    Tests behave_as().
+    """
     self.given('I press add')
 
 

--- a/tests/simple_app/features/steps.py
+++ b/tests/simple_app/features/steps.py
@@ -62,7 +62,7 @@ def press_plus(self):
 
 
 @step(r'I have a table')
-def press_add(self):
+def have_table(self):
     """Nothing."""
 
 


### PR DESCRIPTION
Basic implementation of the Cucumber outputter as verbosity level 3.

It's a bit hacky, but I can't work out how to register the hook in the TestResult to run the steps etc. This is a workaround which is probably okay, so long as multiple things aren't streaming simultaneously.

Perhaps we want to set the default verbosity to 3 so people get colours by default. It's worth noting that verbosity 3 in Django is quite verbose.
