### PR TITLE
Raise no definition found in each scenario

### DIFF
--- a/aloe/exceptions.py
+++ b/aloe/exceptions.py
@@ -47,3 +47,12 @@ class NoDefinitionFound(Exception):
 # so force encoding the message as Unicode.
 if not PY3:
     NoDefinitionFound.__str__ = lambda self: self.message.encode('utf-8')
+
+
+def not_defined_step(step, *args, **kwargs):
+    """
+    Fallback used when no suitable step definition was found.
+
+    Forces the NoDefinitionFound to be raised at scenario run level.
+    """
+    raise NoDefinitionFound(step)

--- a/aloe/registry.py
+++ b/aloe/registry.py
@@ -21,7 +21,7 @@ from functools import wraps, partial
 
 from aloe.codegen import multi_manager
 from aloe.exceptions import (
-    NoDefinitionFound,
+    not_defined_step,
     StepLoadingError,
 )
 from aloe.utils import unwrap_function
@@ -290,7 +290,7 @@ class StepDict(dict):
                     args = matched.groups()
                     return (func, args, {})
 
-        raise NoDefinitionFound(step_)
+        return (not_defined_step, (), {})
 
     def step(self, step_func_or_sentence):
         """

--- a/tests/functional/test_simple.py
+++ b/tests/functional/test_simple.py
@@ -146,8 +146,8 @@ AssertionError
 
         output = stream.getvalue()
 
-        error_header = "ERROR: Failure: NoDefinitionFound " + \
-            "(The step r\"When I engage the warp drive\" is not defined)"
+        error_header = "NoDefinitionFound: " + \
+            "The step r\"When I engage the warp drive\" is not defined"
 
         self.assertIn(error_header, output)
 
@@ -164,8 +164,8 @@ AssertionError
 
         output = stream.getvalue()
 
-        error_header = "ERROR: Failure: NoDefinitionFound " + \
-            "(The step r\"当我开曲速引擎\" is not defined)"
+        error_header = "NoDefinitionFound: " + \
+            "The step r\"当我开曲速引擎\" is not defined"
 
         self.assertIn(error_header, output)
 


### PR DESCRIPTION
Fixes #55.

Avoid raise NoDefinitionFound at steps registry time to avoid block a whole features file because one scenario with undefined step. The error will be delayed to execution and, if the scenario is excluded by tags, the error won't even happen.
