### PR TITLE
Uses nose importer to load steps files.

### DIFF
--- a/aloe/fs.py
+++ b/aloe/fs.py
@@ -60,7 +60,6 @@ class FeatureLoader(object):
                 module = importer.importFromPath(filename, module_name)
                 reload(module)  # Make sure steps and hooks are registered
 
-
     @classmethod
     def find_feature_directories(cls, dir_):
         """

--- a/aloe/fs.py
+++ b/aloe/fs.py
@@ -13,13 +13,13 @@ standard_library.install_aliases()
 import os
 import fnmatch
 
-from importlib import import_module
 try:
     reload
 except NameError:
     # pylint:disable=no-name-in-module,redefined-builtin
     from importlib import reload
     # pylint:enable=no-name-in-module,redefined-builtin
+from nose.importer import Importer
 
 
 def path_to_module_name(filename):
@@ -50,15 +50,16 @@ class FeatureLoader(object):
         """
         Load the steps from the specified directory.
         """
+        importer = Importer()
 
         for path, _, files in os.walk(dir_):
             for filename in fnmatch.filter(files, '*.py'):
                 # Import the module using its fully qualified name
                 filename = os.path.relpath(os.path.join(path, filename))
                 module_name = path_to_module_name(filename)
-
-                module = import_module(module_name)
+                module = importer.importFromPath(filename, module_name)
                 reload(module)  # Make sure steps and hooks are registered
+
 
     @classmethod
     def find_feature_directories(cls, dir_):


### PR DESCRIPTION
You got the point @koterpillar, I seek how nose searches for test files and found the nose Importer class.

The aloe tests passed here in py2.7 and py3. The tests I done myself passed too. I didn't find a way to make the tests fail for this bug, but I can search out in the next week if you didn't find before me.
