### PR TITLE
Allow different features dir

### DIFF
--- a/aloe/fs.py
+++ b/aloe/fs.py
@@ -18,6 +18,9 @@ from nose.importer import Importer
 from aloe.exceptions import StepDiscoveryError
 
 
+GHERKIN_FEATURES_DIR_NAME = 'GHERKIN_FEATURES_DIR_NAME'
+
+
 def path_to_module_name(filename):
     """Convert a path to a file to a Python module name."""
 
@@ -66,14 +69,37 @@ class FeatureLoader(object):
                     )
 
     @classmethod
+    def features_dirname(cls):
+        """
+        Set the name of the features directory.
+        It is possible to change the name by setting the environment variable:
+        GHERKIN_FEATURES_DIR_NAME = 'gherkin_features'
+        """
+
+        env = os.environ
+        features_dirname = env.get(GHERKIN_FEATURES_DIR_NAME, 'features')
+
+        # check the dir name is not a path
+        if '/' in features_dirname:
+            raise_from(
+                StepDiscoveryError("%s cannot be a path: %s" % (
+                    GHERKIN_FEATURES_DIR_NAME, features_dirname)),
+                None
+            )
+
+        return features_dirname
+
+    @classmethod
     def find_feature_directories(cls, dir_):
         """
         Locate directories to load features from.
 
-        The directories must be named 'features'; they must either reside
+        The directories should be named 'features'; they must either reside
         directly in the specified directory, or otherwise all their parents
         must be packages (have __init__.py files).
         """
+
+        features_dirname = cls.features_dirname()
 
         # A set of package directories discovered
         packages = set()
@@ -85,8 +111,8 @@ class FeatureLoader(object):
 
             if path == dir_ or path in packages:
                 # Does this package have a feature directory?
-                if 'features' in dirs:
-                    yield os.path.join(path, 'features')
+                if features_dirname in dirs:
+                    yield os.path.join(path, features_dirname)
 
             else:
                 # This is not a package, prune search

--- a/tests/functional/test_step_loading.py
+++ b/tests/functional/test_step_loading.py
@@ -53,3 +53,47 @@ class StepLoadingTest(FeatureTest):
                 'submodule/features/third.feature',
             )
         ])
+
+    def test_single_alternative_feature(self):
+        """
+        Test running a single feature in the alternative features directory.
+        """
+
+        os.environ['GHERKIN_FEATURES_DIR_NAME'] = 'alternative_features'
+
+        self.assert_feature_success('alternative_features/single.feature')
+
+        del os.environ['GHERKIN_FEATURES_DIR_NAME']
+
+    def test_alternative_subdirectory_feature(self):
+        """
+        Test running a feature in a subdirectory of the alternative features
+        directory.
+        """
+
+        os.environ['GHERKIN_FEATURES_DIR_NAME'] = 'alternative_features'
+
+        self.assert_feature_success(
+            'alternative_features/subdirectory/another.feature')
+
+        del os.environ['GHERKIN_FEATURES_DIR_NAME']
+
+    def test_all_alternative_features(self):
+        """
+        Test running all the features under the alternative features directory
+        without explicitly specifying them.
+        """
+
+        os.environ['GHERKIN_FEATURES_DIR_NAME'] = 'alternative_features'
+
+        result = self.assert_feature_success()
+
+        del os.environ['GHERKIN_FEATURES_DIR_NAME']
+
+        self.assertEqual(result.tests_run, [
+            os.path.abspath(feature) for feature in (
+                'alternative_features/single.feature',
+                'alternative_features/subdirectory/another.feature',
+                'submodule/alternative_features/third.feature',
+            )
+        ])

--- a/tests/step_definition_app/alternative_features/single.feature
+++ b/tests/step_definition_app/alternative_features/single.feature
@@ -1,0 +1,5 @@
+Feature: Test loading feature from the root features directory
+
+  Scenario: Use steps
+    Given I use alternative step one
+    And I use alternative step two

--- a/tests/step_definition_app/alternative_features/steps/__init__.py
+++ b/tests/step_definition_app/alternative_features/steps/__init__.py
@@ -1,0 +1,3 @@
+"""
+Step module for the test application.
+"""

--- a/tests/step_definition_app/alternative_features/steps/one.py
+++ b/tests/step_definition_app/alternative_features/steps/one.py
@@ -1,0 +1,12 @@
+"""
+Part of steps for the tested application.
+"""
+# pylint:disable=unused-argument
+
+from aloe import step
+
+
+@step(r'I use alternative step one')
+def step_one(self):
+    """Dummy step."""
+    pass

--- a/tests/step_definition_app/alternative_features/steps/two.py
+++ b/tests/step_definition_app/alternative_features/steps/two.py
@@ -1,0 +1,15 @@
+"""
+Part of steps for the tested application.
+"""
+
+# pylint:disable=unused-argument,unused-import
+
+from aloe import step
+
+from .one import step_one
+
+
+@step(r'I use alternative step two')
+def step_two(self):
+    """Dummy step."""
+    pass

--- a/tests/step_definition_app/alternative_features/subdirectory/another.feature
+++ b/tests/step_definition_app/alternative_features/subdirectory/another.feature
@@ -1,0 +1,5 @@
+Feature: Test loading feature from a subdirectory
+
+  Scenario: Use steps
+    Given I use alternative step one
+    And I use alternative step two

--- a/tests/step_definition_app/submodule/alternative_features/third.feature
+++ b/tests/step_definition_app/submodule/alternative_features/third.feature
@@ -1,0 +1,5 @@
+Feature: Test loading feature from a submodule
+
+  Scenario: Use steps
+    Given I use alternative step one
+    And I use alternative step two

--- a/tests/unit/test_fs.py
+++ b/tests/unit/test_fs.py
@@ -7,9 +7,11 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
+import os
 import unittest
 
-from aloe.fs import path_to_module_name
+from aloe.exceptions import StepDiscoveryError
+from aloe.fs import FeatureLoader, path_to_module_name
 
 
 class PathToModuleNameTest(unittest.TestCase):
@@ -29,3 +31,16 @@ class PathToModuleNameTest(unittest.TestCase):
             'one.two',
             path_to_module_name('one/two/__init__.py')
         )
+
+
+class AlternativeFeaturesDirTest(unittest.TestCase):
+    """Test alternative features directory."""
+
+    def test_alternative_directory(self):
+        """Test alternative directory is not a path"""
+
+        with self.assertRaises(StepDiscoveryError):
+            os.environ['GHERKIN_FEATURES_DIR_NAME'] = 'my/features'
+            FeatureLoader.features_dirname()
+
+        del os.environ['GHERKIN_FEATURES_DIR_NAME']


### PR DESCRIPTION
Allow to specify an alternative features directory

Useful when for some unfortunate reason there is already a directory called features.
