### PR TITLE
Extend step decorator

### DIFF
--- a/aloe/__init__.py
+++ b/aloe/__init__.py
@@ -16,6 +16,8 @@ from aloe.registry import (
     after,
     around,
     before,
+    extended_step,
+    register_placeholder,
     step,
 )
 


### PR DESCRIPTION
Defines commonly used regexes for strings and numbers.
When using the string placeholder, the decorator creates two different steps to catch single and double quoted strings.

It also allows to register more placeholders to be replaced.
