### PR TITLE
Add tests for calling non-ASCII step definitions from behave_as

### DIFF
--- a/tests/callbacks_app/features/behave_as_ru.feature
+++ b/tests/callbacks_app/features/behave_as_ru.feature
@@ -4,11 +4,11 @@
   Проверка работы behave_as на русском языке
 
   Контекст:
-    Пусть I emit a step event of "Z"
-    И I emit a step event for each letter in "BC"
+    Пусть я записываю событие step "Z"
+    И я записываю событие step для каждой буквы в "BC"
 
   Сценарий: Проверка behave_as
-    Пусть I emit a step event of "A"
-    И I emit a step event for each letter in "DE"
+    Пусть я записываю событие step "A"
+    И я записываю событие step для каждой буквы в "DE"
     # Last two brackets are from the current example
-    Тогда the step event sequence should be "{[Z]}{[{[B]}{[C]}]}{[A]}{[{[D]}{[E]}]}{["
+    Тогда последовательность событий step должна быть "{[Z]}{[{[B]}{[C]}]}{[A]}{[{[D]}{[E]}]}{["

--- a/tests/callbacks_app/features/steps.py
+++ b/tests/callbacks_app/features/steps.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Steps for testing the basic Gherkin test functionality.
 """
@@ -162,6 +163,7 @@ def after_all():
 
 
 @step(r'I emit an? ([^ ]+) event of "([^"]+)"')
+@step(r'Я записываю событие ([^ ]+) "([^"]+)"')
 def emit_event(self, kind, event):
     """Record a user-defined event."""
     record_event(kind, event)
@@ -182,7 +184,24 @@ def emit_event_letters(self, kind, letters):
         ))
 
 
+@step(r'Я записываю событие ([^ ]+) для каждой буквы в "([^"]+)"')
+def emit_event_letters_ru(self, kind, letters):
+    """
+    Record several user-defined events in succession, using the Russian step
+    definition.
+
+    Used to test behave_as.
+    """
+
+    for letter in letters:
+        self.when('Я записываю событие {kind} "{letter}"'.format(
+            kind=kind,
+            letter=letter,
+        ))
+
+
 @step(r'The ([^ ]+) event sequence should be "([^"]+)"')
+@step(r'Последовательность событий ([^ ]+) должна быть "([^"]+)"')
 def check_events(self, kind, events):
     """Check the recorded events of a particular type."""
     kind = kind.replace('"', '')


### PR DESCRIPTION
Checking the bug reported in #95.
