### PR TITLE
Explicitly require v0.14.0 or greater of `python-future` library.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 blessings
-future
+future>=0.14.0
 gherkin-official
 nose
 repoze.lru


### PR DESCRIPTION
I attempted to install aloe into my virtual environment which already had an older version of `future` installed (v0.9.0) and was using Python 2.7.11. I tried to run some tests, but was getting a `ImportError: No module named builtins`. I quickly discovered that v0.14.0 of `future` is the minimum version necessary to run aloe with Python 2.x , because of the re-organization of top-level packages.

http://python-future.org/changelog.html#changes-in-version-0-14-0-2014-10-02
