### PR TITLE
Fix factory names generation

### DIFF
--- a/aloe/steps/factoryboy.py
+++ b/aloe/steps/factoryboy.py
@@ -78,9 +78,15 @@ def step_from_factory(factory):
     object. If a number of objects is requested, at most one row can be given,
     passed as `kwargs` to :meth:`factory.Factory.create_batch`.
 
-    The name of the object and its plural are taken from
-    :attr:`factory.Factory._meta` if set, or otherwise inferred from the
-    class name.
+    The name of the object and its plural can be specified as:
+
+    - :code:`_verbose_name` and :code:`_verbose_name_plural` attributes on the
+      factory;
+    - If the factory creates a Django model, :code:`verbose_name` and
+      :code:`verbose_name_plural` of the model;
+
+    If neither is specified, the object name is inferred from the factory class
+    name.
 
     Example:
 
@@ -95,6 +101,8 @@ def step_from_factory(factory):
 
             first_name = factory.Faker('first_name')
             last_name = factory.Faker('last_name')
+
+            _verbose_name = "random user"
 
     .. code-block:: gherkin
 

--- a/aloe/steps/factoryboy.py
+++ b/aloe/steps/factoryboy.py
@@ -53,9 +53,9 @@ def _get_factory_attr(factory, attr):
     """
     Try getting a meta attribute 'attr' from a factory.
 
-    The attribute is looked up as '_attr' on the factory, then as 'attr' on its
-    model's meta. The factory's own meta cannot define custom attributes and is
-    skipped.
+    The attribute is looked up as '_attr' on the factory, then, if the factory
+    and its model class names match, as 'attr' on the model's meta. The
+    factory's own meta cannot define custom attributes and is skipped.
 
     If the attribute is not found in either place, an AttributeError is raised.
     """
@@ -63,7 +63,11 @@ def _get_factory_attr(factory, attr):
     try:
         return getattr(factory, '_' + attr)
     except AttributeError:
-        return getattr(factory._meta.model._meta, attr)  # pylint:disable=protected-access
+        # pylint:disable=protected-access
+        if factory.__name__ == factory._meta.model.__name__ + 'Factory':
+            return getattr(factory._meta.model._meta, attr)
+        else:
+            raise
 
 
 def step_from_factory(factory):
@@ -82,8 +86,9 @@ def step_from_factory(factory):
 
     - :code:`_verbose_name` and :code:`_verbose_name_plural` attributes on the
       factory;
-    - If the factory creates a Django model, :code:`verbose_name` and
-      :code:`verbose_name_plural` of the model;
+    - If the factory creates a Django model, and its name corresponds to the
+      model class name (e.g. :code:`UserFactory` and :code:`User`),
+      :code:`verbose_name` and :code:`verbose_name_plural` of the model;
 
     If neither is specified, the object name is inferred from the factory class
     name.

--- a/tests/factoryboy_app/features/good.feature
+++ b/tests/factoryboy_app/features/good.feature
@@ -59,7 +59,7 @@ Feature: Test Factory Boy steps
             | name       |
             | Black Mesa |
             | Combine    |
-        And I have a mysterious agency
+        And I have a boring agency
         And I have 2 mysterious agencies
 
         Then I made 6 agencies

--- a/tests/factoryboy_app/features/steps.py
+++ b/tests/factoryboy_app/features/steps.py
@@ -82,6 +82,7 @@ class Agency(object):
     class _meta(object):
         """Meta, defined to mimic Django models."""
 
+        verbose_name = "agency"
         verbose_name_plural = "agencies"
 
     def __init__(self, name):
@@ -102,8 +103,17 @@ class AgencyFactory(factory.Factory):
 
 
 @step_from_factory
+class BoringAgencyFactory(AgencyFactory):
+    """Customized factory to build agencies."""
+
+    # This factory will have registered steps according to its name - "boring
+    # agency"
+    pass
+
+
+@step_from_factory
 class SecretAgencyFactory(AgencyFactory):
-    """Another factory to build agencies."""
+    """Another customized factory to build agencies."""
 
     _verbose_name = "mysterious agency"
     _verbose_name_plural = "mysterious agencies"

--- a/tests/factoryboy_app/features/steps.py
+++ b/tests/factoryboy_app/features/steps.py
@@ -102,7 +102,7 @@ class AgencyFactory(factory.Factory):
 
 
 @step_from_factory
-class MysteriousAgencyFactory(AgencyFactory):
+class SecretAgencyFactory(AgencyFactory):
     """Another factory to build agencies."""
 
     _verbose_name = "mysterious agency"


### PR DESCRIPTION
<s>Object names in factory steps are only derived from the factory class
name if the object factory creates is not a Django model. Reflect that
in the documentation and make the tests unambigious.</s>

Only look at `verbose_name{,_plural}` if the factory name matches the model name.

See #110 for the original bug report.
