### PR TITLE
Add nose plugin entry point to allow running BDD tests via normal `nosetests` client

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,12 @@ Read the [documentation][docs].
 Invocation
 ----------
 
-`aloe` command line tool is a wrapper for the `nose` runner, configured to only
-run Gherkin tests. As such, the invocation is the same as `nose`, but the
+Pass the `--with-gherkin` argument to `nosetests` to run your BDD tests.  You
+may also pass the `--no-ignore-python` argument to run other nose discovered
+tests as well.
+
+The `aloe` command line tool is a wrapper for the `nose` runner, configured to
+only run Gherkin tests. As such, the invocation is the same as `nose`, but the
 following parameters are added:
 
 * `-n N[,N...]` - only run the specified scenarios (by number, 1-based) in each

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,9 @@ if __name__ == '__main__':
             include_package_data=True,
 
             entry_points={
+                'nose.plugins.0.10': [
+                    'aloe = aloe.plugin:GherkinPlugin',
+                ],
                 'console_scripts': [
                     'aloe = aloe:main',
                 ],


### PR DESCRIPTION
The changes to `setup.py` allow nose to find and use the plugin directly from the normal `nosetests` command line client, rather than requiring use of the special `aloe` client.  I'd prefer that we didn't have to pass `--no-ignore-python` and that other tests ran by default, but that may be the subject of a different PR.
