### PR TITLE
Deprecate aloe command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,11 @@ Read the [documentation][docs].
 Invocation
 ----------
 
-Pass the `--with-gherkin` argument to `nosetests` to run your BDD tests.  You
-may also pass the `--no-ignore-python` argument to run other nose discovered
-tests as well.
+Pass the `--with-gherkin` argument to `nosetests` to run your BDD tests.
 
-The `aloe` command line tool is a wrapper for the `nose` runner, configured to
-only run Gherkin tests. As such, the invocation is the same as `nose`, but the
-following parameters are added:
+The `aloe` command line tool is a deprecated wrapper for the `nose` runner,
+configured to only run Gherkin tests. As such, the invocation is the same as
+`nose`, but the following parameters are added:
 
 * `-n N[,N...]` - only run the specified scenarios (by number, 1-based) in each
   feature. Makes sense when only specifying one feature to run, for example

--- a/aloe/__init__.py
+++ b/aloe/__init__.py
@@ -9,7 +9,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-import sys
 import threading
 
 from aloe.registry import (
@@ -20,18 +19,3 @@ from aloe.registry import (
 )
 
 world = threading.local()  # pylint:disable=invalid-name
-
-
-def main(argv=None):  # pragma: no cover
-    """
-    Entry point for running Aloe.
-    """
-
-    if argv is None:
-        argv = sys.argv
-
-    from aloe.runner import Runner
-    Runner(argv)
-
-if __name__ == '__main__':  # pragma: no cover
-    main()

--- a/aloe/__main__.py
+++ b/aloe/__main__.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Main module.
+"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+import sys
+import time
+
+
+def main(argv=None):  # pragma: no cover
+    """
+    Entry point for running Aloe.
+    """
+
+    import aloe.plugin
+    aloe.plugin.USING_DEPRECATED_RUNNER = True
+    sys.stderr.write(
+        '**************************************************\n'
+        '*        The `aloe` command is deprecated.       *\n'
+        '*     Run `nosetests --with-gherkin` instead.    *\n'
+        '*          ...sleeping for 3 seconds...          *\n'
+        '**************************************************\n'
+    )
+    time.sleep(3)
+
+    if argv is None:
+        argv = sys.argv
+
+    from aloe.runner import Runner
+    Runner(argv)
+main.USING_DEPRECATED_RUNNER = False
+
+if __name__ == '__main__':  # pragma: no cover
+    main()

--- a/aloe/plugin.py
+++ b/aloe/plugin.py
@@ -24,6 +24,9 @@ from aloe.testclass import TestCase
 from aloe.result import AloeTestResult
 
 
+USING_DEPRECATED_RUNNER = False
+
+
 class GherkinPlugin(Plugin):
     """
     Collect Gherkin tests.
@@ -75,29 +78,35 @@ class GherkinPlugin(Plugin):
 
         test_class_name = \
             '{c.__module__}.{c.__name__}'.format(c=self.TEST_CLASS)
+
+        # default values for command line arguments
+        parser.set_defaults(
+            test_class_name=env.get('NOSE_GHERKIN_CLASS', test_class_name),
+            ignore_python=USING_DEPRECATED_RUNNER,
+            scenario_indices='',
+            force_color=False,
+        )
+
         parser.add_option(
             '--test-class', action='store',
             dest='test_class_name',
-            default=env.get('NOSE_GHERKIN_CLASS', test_class_name),
             metavar='TEST_CLASS',
             help='Base class to use for the generated tests',
         )
-        parser.add_option(
-            '--no-ignore-python', action='store_false',
-            dest='ignore_python',
-            default=True,
-            help='Run Python and Gherkin tests together',
-        )
+        if USING_DEPRECATED_RUNNER:
+            parser.add_option(
+                '--no-ignore-python', action='store_false',
+                dest='ignore_python',
+                help='Run Python and Gherkin tests together',
+            )
         parser.add_option(
             '-n', '--scenario-indices', action='store',
             dest='scenario_indices',
-            default='',
             help='Only run scenarios with these indices (comma-separated)',
         )
         parser.add_option(
             '--color', action='store_true',
             dest='force_color',
-            default=False,
             help='Force colored output',
         )
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ if __name__ == '__main__':
                     'aloe = aloe.plugin:GherkinPlugin',
                 ],
                 'console_scripts': [
-                    'aloe = aloe:main',
+                    'aloe = aloe.__main__:main',
                 ],
             },
 


### PR DESCRIPTION
A continuation of https://github.com/aloetesting/aloe/pull/114 but deprecating the `aloe` command altogether.
