### PR TITLE
Fix non-ASCII steps in outputter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## Unreleased
+
+### Fixed
+
+- Steps with non-ASCII characters can be run in verbose output mode on
+  Python 2.7 (#123).
+
 ## 0.1.8
 
 ### Fixed

--- a/aloe/parser.py
+++ b/aloe/parser.py
@@ -639,7 +639,10 @@ class Description(Node):
         """
 
         line = self.lines[idx]
-        result = ' ' * self.indent + line
+        if line:
+            result = ' ' * self.indent + line
+        else:
+            result = ''
 
         return result
 

--- a/aloe/result.py
+++ b/aloe/result.py
@@ -22,7 +22,7 @@ from aloe.registry import (
 )
 from aloe.strings import ljust, represent_table
 from aloe.tools import hook_not_reentrant
-from aloe.utils import memoizedproperty
+from aloe.utils import memoizedproperty, PY3
 from nose.result import TextTestResult
 
 # A decorator to add callbacks which wrap the steps looser than all the other
@@ -83,6 +83,11 @@ class Terminal(blessings.Terminal):
         :param return_: if True return the cursor back to where it was
             before the write.
         """
+
+        # On Python 2, the default output encoding is ASCII
+        if not PY3:
+            arg = arg.encode('utf-8')
+
         self.stream.write(arg)
 
         if return_:

--- a/aloe/utils.py
+++ b/aloe/utils.py
@@ -56,13 +56,10 @@ else:
             and unicode.
             """
 
-            # pylint:disable=super-on-old-class
-            # https://bitbucket.org/logilab/pylint/issues/721
             try:
                 super().write(str_)
             except TypeError:
                 super().write(str_.decode('utf-8'))
-            # pylint:enable=super-on-old-class
 
 
 def unwrap_function(func):

--- a/tests/functional/test_outputter.py
+++ b/tests/functional/test_outputter.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Test level 3 outputter
 """
@@ -84,12 +85,14 @@ Feature: Highlighting
   I want to see my scenarios with pretty highlighting
   So my output is easy to read
 
-  Scenario: behave_as works                            # features/highlighting.feature:13
+  非ASCII字显示得正常
+
+  Scenario: behave_as works                            # features/highlighting.feature:15
     Given I have a table
     Given I have entered 10 into the calculator
     And I press [+]
 
-  Scenario Outline: Scenario outlines                  # features/highlighting.feature:17
+  Scenario Outline: Scenario outlines                  # features/highlighting.feature:19
       | number |
       | 30     |
 
@@ -97,7 +100,7 @@ Feature: Highlighting
     Given I have entered 30 into the calculator
     And I press add
 
-  Scenario Outline: Scenario outlines                  # features/highlighting.feature:17
+  Scenario Outline: Scenario outlines                  # features/highlighting.feature:19
       | number |
       | 40     |
 
@@ -106,7 +109,7 @@ Feature: Highlighting
     And I press add
 
   @tables
-  Scenario: Scenario with table                        # features/highlighting.feature:27
+  Scenario: Scenario with table                        # features/highlighting.feature:29
     Given I have a table
     Given I have a table:
       | value |
@@ -114,7 +117,7 @@ Feature: Highlighting
       | 1     |
       | 2     |
 
-  Scenario: Scenario with a multiline                  # features/highlighting.feature:34
+  Scenario: Scenario with a multiline                  # features/highlighting.feature:36
     Given I have a table
     Given I have a table:
       \"\"\"
@@ -142,12 +145,14 @@ Feature: Highlighting
   I want to see my scenarios with pretty highlighting
   So my output is easy to read
 
-  Scenario: behave_as works                            t.grey(# features/highlighting.feature:13)
+  非ASCII字显示得正常
+
+  Scenario: behave_as works                            t.grey(# features/highlighting.feature:15)
 t.green(Given I have a table)
 t.green(Given I have entered 10 into the calculator)
 t.green(And I press [+])
 
-  Scenario Outline: Scenario outlines                  t.grey(# features/highlighting.feature:17)
+  Scenario Outline: Scenario outlines                  t.grey(# features/highlighting.feature:19)
       | number |
       | 30     |
 
@@ -155,7 +160,7 @@ t.green(Given I have a table)
 t.green(Given I have entered 30 into the calculator)
 t.green(And I press add)
 
-  Scenario Outline: Scenario outlines                  t.grey(# features/highlighting.feature:17)
+  Scenario Outline: Scenario outlines                  t.grey(# features/highlighting.feature:19)
       | number |
       | 40     |
 
@@ -164,7 +169,7 @@ t.green(Given I have entered 40 into the calculator)
 t.green(And I press add)
 
 t.cyan(@tables)
-  Scenario: Scenario with table                        t.grey(# features/highlighting.feature:27)
+  Scenario: Scenario with table                        t.grey(# features/highlighting.feature:29)
 t.green(Given I have a table)
 t.green(Given I have a table:)
       | t.green(value) |
@@ -172,7 +177,7 @@ t.green(Given I have a table:)
       | t.green(1) |
       | t.green(2) |
 
-  Scenario: Scenario with a multiline                  t.grey(# features/highlighting.feature:34)
+  Scenario: Scenario with a multiline                  t.grey(# features/highlighting.feature:36)
 t.green(Given I have a table)
 t.green(Given I have a table:)
       \"\"\"
@@ -215,12 +220,14 @@ Feature: Highlighting
   I want to see my scenarios with pretty highlighting
   So my output is easy to read
 
-  Scenario: behave_as works                            t.grey(# features/highlighting.feature:13)
+  非ASCII字显示得正常
+
+  Scenario: behave_as works                            t.grey(# features/highlighting.feature:15)
 t.blue(Given I have a table)
 t.blue(Given I have entered 10 into the calculator)
 t.blue(And I press [+])
 
-  Scenario Outline: Scenario outlines                  t.grey(# features/highlighting.feature:17)
+  Scenario Outline: Scenario outlines                  t.grey(# features/highlighting.feature:19)
       | number |
       | 30     |
 
@@ -228,7 +235,7 @@ t.blue(Given I have a table)
 t.blue(Given I have entered 30 into the calculator)
 t.blue(And I press add)
 
-  Scenario Outline: Scenario outlines                  t.grey(# features/highlighting.feature:17)
+  Scenario Outline: Scenario outlines                  t.grey(# features/highlighting.feature:19)
       | number |
       | 40     |
 
@@ -237,7 +244,7 @@ t.blue(Given I have entered 40 into the calculator)
 t.blue(And I press add)
 
 t.cyan(@tables)
-  Scenario: Scenario with table                        t.grey(# features/highlighting.feature:27)
+  Scenario: Scenario with table                        t.grey(# features/highlighting.feature:29)
 t.blue(Given I have a table)
 t.blue(Given I have a table:)
       | t.blue(value) |
@@ -245,7 +252,7 @@ t.blue(Given I have a table:)
       | t.blue(1) |
       | t.blue(2) |
 
-  Scenario: Scenario with a multiline                  t.grey(# features/highlighting.feature:34)
+  Scenario: Scenario with a multiline                  t.grey(# features/highlighting.feature:36)
 t.blue(Given I have a table)
 t.blue(Given I have a table:)
       \"\"\"
@@ -278,7 +285,9 @@ Feature: Highlighting
   I want to see my scenarios with pretty highlighting
   So my output is easy to read
 
-  Scenario: behave_as works                            t.grey(# features/highlighting.feature:13)
+  非ASCII字显示得正常
+
+  Scenario: behave_as works                            t.grey(# features/highlighting.feature:15)
 t.grey(Given I have a table
     Given I have entered 10 into the calculator
     And I press [+])

--- a/tests/integration/test_simple.py
+++ b/tests/integration/test_simple.py
@@ -32,6 +32,17 @@ class SimpleIntegrationTest(unittest.TestCase):
         exitcode, _ = self.run_feature('features/calculator.feature')
         self.assertEqual(exitcode, 0, "Feature run successfully.")
 
+    def test_success_zh(self):
+        """
+        Test running a simple feature with non-ASCII characters, with verbose
+        output.
+        """
+
+        exitcode, out = self.run_feature('features/calculator_zh.feature',
+                                         '--verbosity=3')
+        print(out)
+        self.assertEqual(exitcode, 0, "Feature run successfully.")
+
     def test_failure(self):
         """
         Test running a failing feature.

--- a/tests/simple_app/features/highlighting.feature
+++ b/tests/simple_app/features/highlighting.feature
@@ -5,6 +5,8 @@ Feature: Highlighting
   I want to see my scenarios with pretty highlighting
   So my output is easy to read
 
+  非ASCII字显示得正常
+
   # Comments are not shown
 
   Background:


### PR DESCRIPTION
Root cause of https://github.com/aloetesting/aloe_django/pull/54.
