### PR TITLE
Make curses dependency optional

### DIFF
--- a/aloe/plugin.py
+++ b/aloe/plugin.py
@@ -21,7 +21,11 @@ from nose.plugins.attrib import AttributeSelector
 from aloe.fs import FeatureLoader
 from aloe.registry import CALLBACK_REGISTRY
 from aloe.testclass import TestCase
-from aloe.result import AloeTestResult
+if os.name == "nt":
+    # We are running on Windows, fall back to plain nose result output
+    from nose.result import TextTestResult as TestResult
+else:
+    from aloe.result import AloeTestResult as TestResult
 
 
 class GherkinPlugin(Plugin):
@@ -246,10 +250,10 @@ class GherkinPlugin(Plugin):
         """
         def _makeResult():
             """Build our result"""
-            return AloeTestResult(runner.stream,
-                                  runner.descriptions,
-                                  runner.verbosity,
-                                  runner.config)
+            return TestResult(runner.stream,
+                              runner.descriptions,
+                              runner.verbosity,
+                              runner.config)
 
         runner._makeResult = _makeResult  # pylint:disable=protected-access
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,6 +5,15 @@
 Aloe is a Gherkin_-based Behavior Driven Development tool for Python based
 on Nose_.
 
+**Note**: Currently the Windows support for `Aloe` is very provisional.
+Since `Aloe` depends on `blessings`_ for its colored terminal output.
+Blessings on the other hand depends on the curses library, which does not
+have native Windows support. In order to make `Aloe` at least usable under
+Windows, colored output is deactivated when the operating system is detected
+to be Windows.
+
+.. _blessings: https://github.com/erikrose/blessings
+
 .. toctree::
     :maxdepth: 2
 


### PR DESCRIPTION
Closes #119 
Aloe depends on curses via the blessings library. Since blessings is
only used for coloring, it can be made optional if under Windows.
This allows Aloe to be usable for Windows users too.

Changes
    * Made the import conditional depending on os.name