### PR TITLE
Export Scenario as a step

### DIFF
--- a/aloe/parser.py
+++ b/aloe/parser.py
@@ -34,6 +34,7 @@ from aloe.registry import STEP_REGISTRY, CALLBACK_REGISTRY, step
 # pylint:disable=abstract-method
 
 LOADED_FEATURES = set()
+STEP_PREFIX = r'(?:Given|And|Then|When) '
 
 class TokenScanner(BaseTokenScanner):
     """Gherkin 3 token scanner that explicitly takes a string or a filename."""
@@ -567,7 +568,7 @@ class Scenario(HeaderNode, TaggedNode, StepContainer):
                     (fun, argsstep, kwargstep) = STEP_REGISTRY.match_step(subs)
                     fun(subs, *argsstep, **kwargstep)
 
-            STEP_REGISTRY.load(self.name, step_scenario)
+            STEP_REGISTRY.load(STEP_PREFIX + self.name, step_scenario)
             sub = re.sub(r'\([^)]*\)', '<%s>', self.name)
             if sub.count("<%s>") == len(keys):
                 self.name = sub % keys
@@ -591,7 +592,7 @@ class Scenario(HeaderNode, TaggedNode, StepContainer):
                     teststep.multiline = step.multiline
                     (fun, argsstep, kwargstep) = STEP_REGISTRY.match_step(teststep)
                     fun(teststep, *argsstep, **kwargstep)
-            STEP_REGISTRY.load(self.name, step_scenario)
+            STEP_REGISTRY.load(STEP_PREFIX + self.name, step_scenario)
 
     indent = 2
 

--- a/aloe/parser.py
+++ b/aloe/parser.py
@@ -552,6 +552,8 @@ class Scenario(HeaderNode, TaggedNode, StepContainer):
             )
             self.regex_name = self.name
 
+            
+            @step(STEP_PREFIX + self.name)
             def step_scenario(self, *args, **kwargs):
                 """ Create a step that executes the scenario steps """
                 for step in steps:
@@ -565,10 +567,13 @@ class Scenario(HeaderNode, TaggedNode, StepContainer):
                         subs = teststep.resolve_substitutions(dict(zip(keys, args)))
 
                     subs.test = self.test
-                    (fun, argsstep, kwargstep) = STEP_REGISTRY.match_step(subs)
-                    fun(subs, *argsstep, **kwargstep)
+                    definition = self.test.prepare_step(subs)
+                    definition['func'](definition['step'],
+                                       *definition['args'],
+                                       **definition['kwargs'])
 
-            STEP_REGISTRY.load(STEP_PREFIX + self.name, step_scenario)
+
+            # STEP_REGISTRY.load(STEP_PREFIX + self.name, step_scenario)
             sub = re.sub(r'\([^)]*\)', '<%s>', self.name)
             if sub.count("<%s>") == len(keys):
                 self.name = sub % keys
@@ -583,6 +588,7 @@ class Scenario(HeaderNode, TaggedNode, StepContainer):
                         keys = keys ))
 
         if self.outline_header is None:
+            @step(STEP_PREFIX + self.name)
             def step_scenario(self, *args, **kwargs):
                 """ Create a step that executes the scenario steps """
                 for step in steps:
@@ -590,9 +596,12 @@ class Scenario(HeaderNode, TaggedNode, StepContainer):
                     teststep.sentence = step.sentence
                     teststep.table = step.table
                     teststep.multiline = step.multiline
-                    (fun, argsstep, kwargstep) = STEP_REGISTRY.match_step(teststep)
-                    fun(teststep, *argsstep, **kwargstep)
-            STEP_REGISTRY.load(STEP_PREFIX + self.name, step_scenario)
+                    definition = self.test.prepare_step(teststep)
+                    definition['func'](definition['step'],
+                                       *definition['args'],
+                                       **definition['kwargs'])
+
+            # STEP_REGISTRY.load(STEP_PREFIX + self.name, step_scenario)
 
     indent = 2
 

--- a/aloe/parser.py
+++ b/aloe/parser.py
@@ -558,6 +558,7 @@ class Scenario(HeaderNode, TaggedNode, StepContainer):
                 """ Create a step that executes the scenario steps """
                 for step in steps:
                     teststep = copy(self)
+                    teststep.depth += 1
                     teststep.sentence = step.sentence
                     teststep.table = step.table
                     teststep.multiline = step.multiline
@@ -593,6 +594,7 @@ class Scenario(HeaderNode, TaggedNode, StepContainer):
                 """ Create a step that executes the scenario steps """
                 for step in steps:
                     teststep = copy(self)
+                    teststep.depth += 1
                     teststep.sentence = step.sentence
                     teststep.table = step.table
                     teststep.multiline = step.multiline

--- a/aloe/parser.py
+++ b/aloe/parser.py
@@ -585,8 +585,12 @@ class Scenario(HeaderNode, TaggedNode, StepContainer):
             def step_scenario(self, *args, **kwargs):
                 """ Create a step that executes the scenario steps """
                 for step in steps:
-                    (fun, argsstep, kwargstep) = STEP_REGISTRY.match_step(step)
-                    fun(step, *argsstep, **kwargstep)
+                    teststep = copy(self)
+                    teststep.sentence = step.sentence
+                    teststep.table = step.table
+                    teststep.multiline = step.multiline
+                    (fun, argsstep, kwargstep) = STEP_REGISTRY.match_step(teststep)
+                    fun(teststep, *argsstep, **kwargstep)
             STEP_REGISTRY.load(self.name, step_scenario)
 
     indent = 2

--- a/aloe/registry.py
+++ b/aloe/registry.py
@@ -301,15 +301,23 @@ class StepDict(object):
         Returns a tuple of (function, args, kwargs).
         """
 
+        matches={}
         for regex, func in self.steps.values():
             matched = regex.search(step_.sentence)
             if matched:
-                kwargs = matched.groupdict()
-                if kwargs:
-                    return (func, (), matched.groupdict())
-                else:
-                    args = matched.groups()
-                    return (func, args, {})
+                matches[regex] = (matched,func)
+
+        if matches:
+            sorted_regex = sorted(matches.items(),key = lambda x : (x[1][0].lastindex,len(x[0].pattern)))
+            mregex,(matched,func) = sorted_regex[-1]
+            if len(sorted_regex) > 1:
+                print("Picked Step",mregex, "From " , len(sorted_regex) ," duplicates steps loaded: ", sorted_regex)
+            kwargs = matched.groupdict()
+            if kwargs:
+                return (func, (), matched.groupdict())
+            else:
+                args = matched.groups()
+                return (func, args, {})
 
         return (undefined_step, (), {})
 

--- a/aloe/registry.py
+++ b/aloe/registry.py
@@ -30,6 +30,7 @@ HOOK_WHAT = (
     'all',
     'feature',
     'example',
+    'outline',
     'step',
 )
 
@@ -453,6 +454,7 @@ class CallbackDecorator(object):
 
     each_step = make_decorator('step')
     each_example = make_decorator('example')
+    each_outline = make_decorator('outline')
     each_feature = make_decorator('feature')
     all = make_decorator('all')
 

--- a/aloe/result.py
+++ b/aloe/result.py
@@ -20,6 +20,7 @@ from aloe.registry import (
     CALLBACK_REGISTRY,
     PriorityClass,
 )
+from aloe.parser import replace_vars
 from aloe.strings import ljust, represent_table
 from aloe.tools import hook_not_reentrant
 from aloe.utils import memoizedproperty, PY3
@@ -168,7 +169,11 @@ def example_wrapper(term, scenario, outline, steps):
         represented = scenario.represented()
         represented = ljust(represented, scenario.feature.max_length + 2)
 
-        term.write(represented)
+        if not outline:
+            term.write(represented)
+        else:
+            term.write(replace_vars(outline, represented))
+
         term.writeln(term.comment('# ' + scenario.location))
 
         if outline:

--- a/aloe/testclass.py
+++ b/aloe/testclass.py
@@ -60,6 +60,7 @@ class TestStep(Step):
         """Initialize the step status."""
         self.failed = None
         self.passed = None
+        self.depth = 0
         super().__init__(*args, **kwargs)
 
     def behave_as(self, string):
@@ -137,6 +138,8 @@ class TestCase(unittest.TestCase):
         # Copy necessary attributes onto new steps
         for step in steps:
             step.test = self
+            step.depth = context_step.depth
+            step.depth+=1
 
             try:
                 step.scenario = context_step.scenario

--- a/aloe/testclass.py
+++ b/aloe/testclass.py
@@ -251,15 +251,15 @@ def run_example(self):
                     index,
                 )
         if scenario.outline_header is None:
-                yield cls.make_example(
-                    cls.make_steps(
-                        scenario,
-                        scenario.steps,
-                        is_background=False,
-                    ),
+            yield cls.make_example(
+                cls.make_steps(
                     scenario,
-                    index,
-                )
+                    scenario.steps,
+                    is_background=False,
+                ),
+                scenario,
+                index,
+            )
 
     @classmethod
     def make_example(cls, method, scenario, index):

--- a/aloe/testclass.py
+++ b/aloe/testclass.py
@@ -220,7 +220,6 @@ class TestCase(unittest.TestCase):
         index is the 1-based number of the scenario in the feature.
         """
 
-        print(scenario.keyword)
         if scenario.outlines :
             outline_example = []
             for i, (outline, steps) in enumerate(scenario.evaluated, 1):

--- a/aloe/testclass.py
+++ b/aloe/testclass.py
@@ -17,6 +17,8 @@ import ast
 import unittest
 from contextlib import contextmanager
 
+import re
+import os
 from nose.plugins.attrib import attr
 
 from aloe.codegen import make_function
@@ -165,7 +167,6 @@ class TestCase(unittest.TestCase):
         """
         Construct a test class from a feature file.
         """
-
         feature = TestFeature.from_file(file_)
 
         background = cls.make_background(feature.background)
@@ -219,7 +220,8 @@ class TestCase(unittest.TestCase):
         index is the 1-based number of the scenario in the feature.
         """
 
-        if scenario.outlines:
+        print(scenario.keyword)
+        if scenario.outlines :
             outline_example = []
             for i, (outline, steps) in enumerate(scenario.evaluated, 1):
                 # Create a function calling the real scenario example to show
@@ -269,8 +271,9 @@ def run_example(self):
                     scenario,
                     index,
                     ))
-
-        if scenario.outline_header is None:
+        if scenario.keyword == 'Scenario Outline':
+            pass
+        elif scenario.outline_header is None:
             yield cls.make_example(
                 cls.make_steps(
                     scenario,

--- a/aloe/testclass.py
+++ b/aloe/testclass.py
@@ -250,16 +250,16 @@ def run_example(self):
                     scenario,
                     index,
                 )
-        else:
-            yield cls.make_example(
-                cls.make_steps(
+        if scenario.outline_header is None:
+                yield cls.make_example(
+                    cls.make_steps(
+                        scenario,
+                        scenario.steps,
+                        is_background=False,
+                    ),
                     scenario,
-                    scenario.steps,
-                    is_background=False,
-                ),
-                scenario,
-                index,
-            )
+                    index,
+                )
 
     @classmethod
     def make_example(cls, method, scenario, index):

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -73,9 +73,13 @@ where each named parameter must be present in the table.
 
 Scenario outlines have a name and may optionally have tags_.
 
+Scenario outlines can be used as Steps if you defined the scenario name as a
+regular expression that matches the parameters. When called the regex are mapped to
+parameters.
+
 .. code-block:: gherkin
 
-        Scenario Outline: Search is correctly escaped
+        Scenario Outline: Search phrase "([^"]*)" should match "([^"]*)"
             When I search for "<Phrase>" and press enter
             Then I should be at <URL>
 
@@ -83,6 +87,10 @@ Scenario outlines have a name and may optionally have tags_.
                 | Phrase   | URL                |
                 | pets     | /search/pets       |
                 | pet food | /search/pet%20food |
+
+        Scenario: Searches
+          Given Search phrase "pets" should match "/search/pets"
+          Given Search phrase "pet food" should match "/search/pets%20food"
 
 Tags
 ----


### PR DESCRIPTION
If we use the scenario name as a regex pattern and all scenarios steps executed as the Step function we can get a kind of macro system for blocks of steps. I found this really useful for abstracting  blocks of application logic into smaller steps.


For example: 

    Scenario Outline : Multiple steps "([^"]*)"  
        Given First Step <name>
        And Second Step <name>
    Examples:
        | name |
        | Foo  |
    Scenario: Call Scenario
        Given Multiple steps Foo


Follows a simple implementation of the idea.  Any comments appreciated.