### PR TITLE
Don't crash on modules with empty paths

### DIFF
--- a/aloe/testing.py
+++ b/aloe/testing.py
@@ -82,6 +82,9 @@ def _in_directory(directory):
                     continue
 
             # Is it loaded from a file in the directory?
+            if not path:
+                continue
+
             path = os.path.abspath(path)
             if not path.startswith(unload_path_prefix):
                 continue

--- a/aloe/utils.py
+++ b/aloe/utils.py
@@ -103,6 +103,7 @@ class memoizedproperty(object):  # pylint:disable=invalid-name
         self.func = func
         self.name = func.__name__
         self.__doc__ = func.__doc__
+        self.__func__ = func  # Compatibility with python-future's newsuper
 
     def __get__(self, instance, owner):
         """Compute the value and cache it in the class dict."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ansicolors>=1.1.8
 colorama>=0.3.9
-future>=0.14.0
+future>=0.17.0
 gherkin-official>=4.1.3, <5
 nose
 repoze.lru


### PR DESCRIPTION
At least in Python 3.7, some modules have `__path__` but it is `None`.