### PR TITLE
Use utf-8 encoding for readme file in setup.py - closes #147

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,15 +3,13 @@ Setup script.
 """
 
 import io
-from os import path
 from setuptools import setup, find_packages
 
 if __name__ == '__main__':
-    this_directory = path.abspath(path.dirname(__file__))
     with \
             open('requirements.txt') as requirements, \
             open('test_requirements.txt') as test_requirements, \
-            io.open(path.join(this_directory, 'README.md'), encoding='utf-8') as readme:
+            io.open('README.md', encoding='utf-8') as readme:
         setup(
             name='aloe',
             use_scm_version=True,

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,16 @@
 Setup script.
 """
 
+import io
+from os import path
 from setuptools import setup, find_packages
 
 if __name__ == '__main__':
+    this_directory = path.abspath(path.dirname(__file__))
     with \
             open('requirements.txt') as requirements, \
             open('test_requirements.txt') as test_requirements, \
-            open('README.md') as readme:
+            io.open(path.join(this_directory, 'README.md'), encoding='utf-8') as readme:
         setup(
             name='aloe',
             use_scm_version=True,


### PR DESCRIPTION
This should fix the codec error.

I've run into the same problem in CommonMark-py, and solved it in the same way: https://github.com/rtfd/CommonMark-py/blob/master/setup.py#L32